### PR TITLE
reorder modules, rename cryptography.

### DIFF
--- a/content/fundamentals/cryptography.mdx
+++ b/content/fundamentals/cryptography.mdx
@@ -1,6 +1,6 @@
 ---
-title: Fundamentals
-description: Cryptography, keys and exercise
+title: Cryptography
+description: Encrypt, decrypt, sign and verify
 slug: fundamentals/cryptography
 ---
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -60,6 +60,8 @@ The course provides theoretical material and a lot of hands-on experience.
 
 The course is organized in a sequential fashion so that novice learners will be able to follow the material, in order, and successfully complete the exercises using the knowledge accumulated from earlier sections. Non-technical learners will discover the gist of designing for Corda by following the narration without necessarily completing the suggested exercises. Advanced learners will discover subtleties and best practices in the description of the exercise solutions - non-obvious considerations, possible solutions and the suggested approach.
 
+If you are new to blockchains and distributed ledgers, start with the [fundamentals](./fundamentals/introduction/) module. This brief overview of the universe of distributed application platforms provides background information that will help you appreciate Corda's unique approach. Carry on to [Key Concepts](./key-concepts/introduction/) to discover Corda's unique approach to distributed applications for enterprise settings. 
+
 <HighlightBox type="support">
 
 Get 3 months access to the authors and experts who created this training.

--- a/content/key-concepts/introduction.mdx
+++ b/content/key-concepts/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Corda
-description: Introducing Corda and generalities
+description: Introducing Corda
 slug: key-concepts/introduction
 ---
 

--- a/content/structure.js
+++ b/content/structure.js
@@ -1,9 +1,9 @@
 module.exports = {
-    "Fundamentals": require("./fundamentals/structure.js"),
     "Key Concepts": require("./key-concepts/structure.js"),
     "Prepare and Discover": require("./prepare-and-discover/structure.js"),
     "Your First Code": require("./first-code/structure.js"),
     "Libraries": require("./libraries/structure.js"),
     "Corda Details": require("./corda-details/structure.js"),
-    "In closing": require("./in-closing/structure.js")
+    "In closing": require("./in-closing/structure.js"),
+    "Fundamentals": require("./fundamentals/structure.js")
 };


### PR DESCRIPTION
This pushes the "Fundamentals" module to last and renames the old Fundamentals/Fundamentals page to Fundamentals/Cryptography.
